### PR TITLE
Fix DICOM tag preservation

### DIFF
--- a/dicom_sorting_tool.py
+++ b/dicom_sorting_tool.py
@@ -142,8 +142,12 @@ def anonymize_dicom_tags(dataset, id_map=None, strict=False, id_from_name=False,
         "20051355"  
     ]
 
-    # Store values of preserved tags
-    preserved_values = {tag: dataset.get(tag) for tag in preserved_tags if tag in dataset}
+    # Store values of preserved tags correctly using Tag objects
+    preserved_values = {}
+    for tag_str in preserved_tags:
+        tag = Tag(int(tag_str, 16))
+        if tag in dataset:
+            preserved_values[tag] = dataset[tag].copy()
 
     # Handle PatientID and PatientName
     original_id = dataset.PatientName if id_from_name else dataset.PatientID
@@ -213,8 +217,8 @@ def anonymize_dicom_tags(dataset, id_map=None, strict=False, id_from_name=False,
             _fix_uids(dataset)
                         
     # Restore preserved tags
-    for tag, value in preserved_values.items():
-        setattr(dataset, tag, value)
+    for tag, data_elem in preserved_values.items():
+        dataset.add(data_elem)
 
     return dataset
     


### PR DESCRIPTION
## Summary
- preserve required tags correctly when anonymizing

## Testing
- `python -m py_compile dicom_sorting_tool.py`
- `python dicom_sorting_tool.py -h | head`

------
https://chatgpt.com/codex/tasks/task_e_68598bbd35108324baa92be5a97b7caa